### PR TITLE
Fix license  (add BSD-2-Clause for bundled bsdiff)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "bsdiff/bsdiff",
     "type": "php-ext",
-    "license": "PHP-3.01",
+    "license": "(PHP-3.01 AND BSD-2-Clause)",
     "description": "A PHP extension to build and apply patches to binary files.",
     "require": {
         "php": ">=7.2.0"

--- a/package.xml
+++ b/package.xml
@@ -19,7 +19,7 @@
   <release>stable</release>
   <api>stable</api>
  </stability>
- <license uri="http://www.php.net/license">PHP License</license>
+ <license uri="http://www.php.net/license">PHP-3.01 AND BSD-2-Clause</license>
  <notes>
 - Add composer.json for installation via PIE (PHP Installer for Extensions).
  </notes>


### PR DESCRIPTION
see bsdiff.c headers


Notice, also nice to add a copy of their LICENSE file

Perhaps also time to consider switching to PHP License version 4 (so BSD-3-Clause)